### PR TITLE
fix path of external/glfw in cmake

### DIFF
--- a/task00/CMakeLists.txt
+++ b/task00/CMakeLists.txt
@@ -23,7 +23,7 @@ project(task00)
 find_package(OpenGL REQUIRED)
 
 # use glfw
-set(CMAKE_PREFIX_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../external/glfwlib) # give hint to cmake to find glfw library
+set(CMAKE_PREFIX_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../external/glfw) # give hint to cmake to find glfw library
 find_package(glfw3 REQUIRED)
 
 ########################

--- a/task01/CMakeLists.txt
+++ b/task01/CMakeLists.txt
@@ -23,7 +23,7 @@ project(task01)
 find_package(OpenGL REQUIRED)
 
 # use glfw
-set(CMAKE_PREFIX_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../external/glfwlib) # give hint to cmake to find glfw library
+set(CMAKE_PREFIX_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../external/glfw) # give hint to cmake to find glfw library
 find_package(glfw3 REQUIRED)
 
 ########################


### PR DESCRIPTION
It seems that the submodule `glfw` path is `glfw`, not `glfwlib`
https://github.com/PBA-2023S/pba/blob/52193558313c947faaa0621431b5c8d52b4c4a48/.gitmodules#L2